### PR TITLE
Update the mext grid serial number pattern

### DIFF
--- a/src/org/monome/Grid.java
+++ b/src/org/monome/Grid.java
@@ -15,7 +15,7 @@ public class Grid extends Device {
 		}
 		if (msg.addrPattern().equals("/sys/id")) {
 			String id = msg.get(0).stringValue();
-			String pattern = "m\\d{7}";
+			String pattern = "m\\d+";
 			if (id.matches(pattern)) {
 				varibright = true;
 			}


### PR DESCRIPTION
Use m\\d+ for compatibility with libmonome. This also adds support for the latest grid, which has 8 digits after "m" instead of 7 in the serial number.